### PR TITLE
add: eth2-quickstart node operator skill

### DIFF
--- a/skills/dev-tools/eth2-quickstart/SKILL.md
+++ b/skills/dev-tools/eth2-quickstart/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: eth2-quickstart
+description: Bootstrap, operate, diagnose, and safely clean production Ethereum validator nodes through a tested command surface with strict safety guardrails.
+version: 1.0.0
+author: chimera-defi
+tags:
+  - ethereum
+  - validator
+  - staking
+  - node
+  - beacon
+  - consensus
+  - execution
+  - mev
+  - devops
+homepage: https://github.com/chimera-defi/eth2-quickstart
+triggers:
+  - "set up an ethereum node"
+  - "install ethereum validator"
+  - "bootstrap beacon node"
+  - "run geth and prysm"
+  - "install consensus client"
+  - "ethereum node setup"
+  - "configure mev-boost"
+  - "clean ethereum node data"
+  - "check ethereum node health"
+config:
+  FEE_RECIPIENT:
+  LOGIN_UNAME:
+---
+
+# Eth2 Quickstart
+
+Automates production-ready Ethereum node setup on Linux servers — execution client, consensus client, MEV integration, OS hardening, and optional RPC exposure. Supports 7 execution clients (Geth, Besu, Nethermind, Erigon, Reth, Nimbus-eth1, Ethrex) and 6 consensus clients (Prysm, Lighthouse, Teku, Nimbus, Lodestar, Grandine).
+
+This skill is **repo-aware**: it runs inside an `eth2-quickstart` checkout and routes all actions through `./scripts/eth2qs.sh`. It never invents new lifecycle commands.
+
+## Install
+
+```bash
+# Recommended
+clawhub install eth2-quickstart
+
+# Or clone directly
+git clone --depth 1 https://github.com/chimera-defi/eth2-quickstart.git
+cd eth2-quickstart
+```
+
+## What agents can do with this skill
+
+- **Bootstrap a fresh host**: detect the next safe install step and execute it
+- **Check node health**: machine-readable JSON output from `doctor --json`
+- **Operate services**: start, stop, restart, view logs
+- **Update clients**: `update-all` covers all installed components
+- **Safe cleanup**: `clean-data --dry-run` shows what would be removed before any deletion; secrets and validator keystores are always preserved
+
+## Commands
+
+```bash
+# Detect the next safe install step (machine-readable)
+./scripts/eth2qs.sh plan --json
+
+# Preview next step without executing
+./scripts/eth2qs.sh ensure
+
+# Execute next step (requires explicit confirmation)
+./scripts/eth2qs.sh ensure --apply --confirm
+
+# Install Ethereum node (execution + consensus + MEV)
+sudo ./scripts/eth2qs.sh phase1
+./scripts/eth2qs.sh phase2 --execution=geth --consensus=prysm --mev=mev-boost
+
+# Health check
+./scripts/eth2qs.sh doctor --json
+
+# Operate
+./scripts/eth2qs.sh start
+./scripts/eth2qs.sh stop
+./scripts/eth2qs.sh logs --run2 -n 200
+./scripts/eth2qs.sh stats
+
+# Cleanup (always dry-run first)
+./scripts/eth2qs.sh clean-data --dry-run
+./scripts/eth2qs.sh clean-data --confirm
+sudo ./scripts/eth2qs.sh cleanup-host --dry-run
+```
+
+## Safety guardrails
+
+- `ensure --apply` requires explicit `--confirm` — no silent destructive execution
+- `clean-data` preserves `~/secrets`, validator keystores, and wallet directories by design
+- `doctor --json` detects service-unit drift (running binary doesn't match unit file)
+- Agents must require human confirmation before phase1 (root/reboot), destructive cleanup, or host-wide changes
+- Agents must never generate validator keys or remove secrets
+
+## `doctor --json` output shape
+
+```json
+{
+  "summary": { "passed": 12, "warnings": 2, "failed": 0, "status": "warn" },
+  "checks": [
+    { "status": "pass", "name": "RAM: 32GB (recommended: 16GB+)", "details": "" },
+    { "status": "warn", "name": "Execution client (eth1): Not installed", "details": "" }
+  ]
+}
+```
+
+Use `doctor --json` as the canonical agent-readable health surface. Use `status` / `stats` / `logs` for human-readable RCA.
+
+## Minimum host requirements
+
+| Spec | Minimum | Recommended |
+|------|---------|-------------|
+| Disk | 2 TB SSD | 4 TB NVMe |
+| RAM | 16 GB | 32 GB |
+| CPU | 4 cores | 8 cores |
+| OS | Ubuntu 20.04+ | Ubuntu 22.04+ |

--- a/skills/dev-tools/eth2-quickstart/SOURCE.md
+++ b/skills/dev-tools/eth2-quickstart/SOURCE.md
@@ -1,0 +1,9 @@
+# Source Attribution
+
+- **Original Author**: chimera-defi
+- **Original Slug**: eth2-quickstart
+- **Source**: https://github.com/chimera-defi/eth2-quickstart
+- **Skill path in source repo**: `skills/eth2-quickstart/`
+- **License**: MIT
+- **Classification**: COMMUNITY
+- **AI involvement**: Mostly AI-generated skill packaging over a human-authored repo

--- a/skills/dev-tools/eth2-quickstart/_meta.json
+++ b/skills/dev-tools/eth2-quickstart/_meta.json
@@ -1,0 +1,10 @@
+{
+  "owner": "chimera-defi",
+  "slug": "eth2-quickstart",
+  "displayName": "Eth2 Quickstart",
+  "latest": {
+    "version": "1.0.0",
+    "publishedAt": 1742601600000
+  },
+  "history": []
+}


### PR DESCRIPTION
**Agent:** Claude Sonnet 4.6

**Co-authored-by:** Chimera <chimera_defi@protonmail.com>

## Summary

Adds the `eth2-quickstart` skill to `skills/dev-tools/`.

This skill automates production-ready Ethereum validator node setup — execution client, consensus client, MEV integration, OS hardening, and optional RPC exposure. Repo-aware, routes all actions through `./scripts/eth2qs.sh`.

## What agents can do with it

- Detect the next safe install step (`plan --json`)
- Preview or execute install phases (`ensure` / `ensure --apply --confirm`)
- Check node health (`doctor --json` — machine-readable JSON)
- Operate services: start, stop, restart, logs
- Safe cleanup: `clean-data --dry-run` shows scope before deletion; secrets and validator keystores always preserved

## Safety guardrails

- `ensure --apply` requires explicit `--confirm`
- Secrets and validator keystores preserved during cleanup by design
- Agents must require human confirmation before phase1 (root/reboot) or host-wide changes
- `doctor --json` detects service-unit drift

## Clients supported

**Execution**: Geth, Besu, Nethermind, Erigon, Reth, Nimbus-eth1, Ethrex  
**Consensus**: Prysm, Lighthouse, Teku, Nimbus, Lodestar, Grandine  
**MEV**: MEV-Boost, Commit-Boost, ETHGas

## Source

- Repo: https://github.com/chimera-defi/eth2-quickstart
- Skill path in repo: `skills/eth2-quickstart/`
- CI-tested: structure, command-mapping, safety, distribution, install e2e

## AI involvement

Skill packaging was mostly AI-generated over a human-authored repo.