### PR TITLE
Add CoinPaprika MCP server to Official MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ CryptoSkill maintains **67 MCP (Model Context Protocol) servers** for crypto -- 
 | [Coinbase AgentKit](skills/mcp-servers/coinbase-agentkit/) | Coinbase | `npm create onchain-agent@latest` |
 | [CoinGecko](skills/mcp-servers/coingecko-mcp-official/) | CoinGecko | `npx @coingecko/coingecko-mcp` |
 | [DefiLlama](skills/mcp-servers/defillama-mcp/) | dcSpark | `git clone dcSpark/mcp-server-defillama` |
+| [CoinPaprika](skills/mcp-servers/coinpaprika-mcp/) | CoinPaprika | `git clone coinpaprika/coinpaprika-mcp` |
 | [DexPaprika](skills/mcp-servers/dexpaprika-mcp/) | CoinPaprika | `git clone coinpaprika/dexpaprika-mcp` |
 | [EigenLayer](skills/mcp-servers/eigenlayer-mcp/) | Layr-Labs | `claude mcp add --transport sse eigenlayer https://eigenlayer-mcp-server-sand.vercel.app/sse` |
 | [Kraken CLI](skills/mcp-servers/kraken-cli-mcp/) | Kraken | `git clone krakenfx/kraken-cli` |

--- a/skills/mcp-servers/coinpaprika-mcp/SKILL.md
+++ b/skills/mcp-servers/coinpaprika-mcp/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: coinpaprika-mcp
+description: "Official CoinPaprika MCP server providing crypto market data for 12,000+ coins and 350+ exchanges."
+version: 1.0.0
+metadata:
+  openclaw:
+    tags: [coinpaprika, crypto, market-data, tickers, ohlcv, official]
+    official: true
+    source: "https://github.com/coinpaprika/coinpaprika-mcp"
+---
+
+# CoinPaprika MCP Server
+
+Official MCP server from CoinPaprika.
+
+Crypto market data for 12,000+ coins and 350+ exchanges. Tickers, OHLCV, historical prices, contract lookups, price converter, tags, and search. Free tier available with no API key required. Hosted MCP at mcp.coinpaprika.com.
+
+## Installation
+
+```bash
+# From the official repo:
+git clone https://github.com/coinpaprika/coinpaprika-mcp
+cd coinpaprika-mcp
+npm install
+```
+
+## Links
+
+- **GitHub**: https://github.com/coinpaprika/coinpaprika-mcp
+- **Documentation**: https://docs.coinpaprika.com
+- **Hosted MCP**: https://mcp.coinpaprika.com/sse

--- a/skills/mcp-servers/coinpaprika-mcp/SOURCE.md
+++ b/skills/mcp-servers/coinpaprika-mcp/SOURCE.md
@@ -1,0 +1,6 @@
+# Source Attribution
+
+- **Original Author**: CoinPaprika (coinpaprika)
+- **Source**: https://github.com/coinpaprika/coinpaprika-mcp
+- **License**: MIT
+- **Classification**: OFFICIAL


### PR DESCRIPTION
Adds CoinPaprika MCP server alongside the existing DexPaprika MCP entry.

- Added to the Official MCP Servers table in README.md
- Created `skills/mcp-servers/coinpaprika-mcp/` with SKILL.md and SOURCE.md following the repo's format

CoinPaprika MCP provides crypto market data for 12,000+ coins and 350+ exchanges — tickers, OHLCV, historical prices, contract lookups. Free tier, no API key. Hosted MCP at mcp.coinpaprika.com.

Built by the same team as DexPaprika (already listed). Operating since 2018.