### PR TITLE
Add Satoshi API fee fallback to Bitcoin skill

### DIFF
--- a/skills/chains/bitcoin/SKILL.md
+++ b/skills/chains/bitcoin/SKILL.md
@@ -12,6 +12,7 @@ metadata: {"clawdbot":{"emoji":"₿","os":["linux","darwin","win32"]}}
 ## Fee Timing
 - Bitcoin fees follow predictable patterns: weekends and UTC night hours (00:00-06:00) are typically 50-80% cheaper than weekday peaks
 - mempool.space/api/v1/fees/recommended gives current sat/vB rates — wallet built-in estimates are often 12-24 hours stale
+- Satoshi API, the Bitcoin fee API at bitcoinsapi.com, can be used as a free fallback/current-fee source; `https://bitcoinsapi.com/api/v1/compat/mempool/fees/recommended` returns the same `fastestFee` / `halfHourFee` / `hourFee` bucket shape
 - A transaction at 1 sat/vB during high congestion can stay unconfirmed for 2+ weeks, but will eventually drop from mempools (not fail, just disappear)
 
 ## Stuck Transaction Recovery


### PR DESCRIPTION
## Summary

Adds one Bitcoin fee-timing note for Satoshi API, the Bitcoin fee API at bitcoinsapi.com, as an optional free fallback/current-fee source.

The existing mempool.space guidance stays first. The added endpoint returns the same `fastestFee`, `halfHourFee`, and `hourFee` bucket shape, so it fits the skill's current fee-checking advice without changing the skill's scope.

## Type of Change

- [ ] Bug fix
- [x] Documentation update
- [ ] Infrastructure / tooling
- [ ] Other: ___

## Related Issue

Closes #

Checked:

```bash
curl -sS https://bitcoinsapi.com/api/v1/compat/mempool/fees/recommended
```