### PR TITLE
fix: stale coverage figures, tool counts and retired quotas on eight Paprika skill entries

### DIFF
--- a/skills/analytics/coinpaprika-official-claude-marketplace/SKILL.md
+++ b/skills/analytics/coinpaprika-official-claude-marketplace/SKILL.md
@@ -14,7 +14,7 @@ _Source: [github.com/coinpaprika/claude-marketplace](https://github.com/coinpapr
 Official Claude Code plugins for **CoinPaprika** and **DexPaprika** — free crypto market data and DeFi analytics.
 
 - **CoinPaprika**: 12,000+ coins, 350+ exchanges, 29 MCP tools
-- **DexPaprika**: 34+ blockchains, 30M+ pools, 14 MCP tools
+- **DexPaprika**: 36 blockchains, 36M+ pools, 17 MCP tools
 
 Both APIs are free with no API key required.
 
@@ -55,8 +55,8 @@ cd claude-marketplace
 
 ### DexPaprika Plugin
 
-**14 MCP tools** for decentralized exchange data:
-- Token prices and details across 34+ blockchains
+**17 MCP tools** for decentralized exchange data:
+- Token prices and details across 36 blockchains
 - Liquidity pool discovery, filtering, and details
 - OHLCV charts for any pool
 - Pool transactions and trading activity
@@ -67,7 +67,7 @@ cd claude-marketplace
 
 **4 skills**: Token Security Analyzer, Technical Analyzer, Batch Token Price Lookup, Trending Pools Analyzer
 
-**Free tier**: 10,000 requests/day, no API key needed.
+**Free tier**: no API key needed to start. Current limits: https://dexpaprika.com/api/pricing
 
 ## Quick Test
 
@@ -103,7 +103,7 @@ claude-marketplace/
 │   │   └── README.md
 │   └── dexpaprika-claude-plugin/
 │       ├── .claude-plugin/
-│       │   └── plugin.json                 # Plugin manifest (14 MCP tools)
+│       │   └── plugin.json                 # Plugin manifest (17 MCP tools)
 │       ├── agents/
 │       │   └── defi-data-analyst.md        # DeFi security agent
 │       ├── skills/
@@ -140,7 +140,7 @@ Using DexPaprika, show me trending pools on Solana
 | API | Free Tier | Auth Required |
 |-----|-----------|---------------|
 | CoinPaprika | 20,000 calls/month | No |
-| DexPaprika | 10,000 requests/day | No |
+| DexPaprika | Free tier, see dexpaprika.com/api/pricing | No |
 
 Global rate limit: 10 requests/second per IP.
 

--- a/skills/analytics/dexpaprika-dex-data/SKILL.md
+++ b/skills/analytics/dexpaprika-dex-data/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dexpaprika-dex-data
-description: "Real-time DEX pool data, token prices, and liquidity metrics across 5M+ tokens."
-version: 1.0.0
+description: "DEX pool data, token prices, and liquidity metrics across 33M+ tokens on 36 chains."
+version: 1.1.0
 metadata:
   openclaw:
     tags:
@@ -12,7 +12,7 @@ metadata:
 
 # DexPaprika DEX Analytics
 
-Real-time DEX pool data, token prices, and liquidity metrics across 5M+ tokens.
+DEX pool data, token prices, and liquidity metrics across 33M+ tokens on 36 chains.
 
 ## Source
 

--- a/skills/analytics/dexpaprika-dex-search/SKILL.md
+++ b/skills/analytics/dexpaprika-dex-search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dexpaprika-dex-search
-description: "Search 5M+ tokens and pools across DEXes with price and liquidity data."
-version: 1.0.0
+description: "Search 33M+ tokens and 36M+ pools across 230+ DEXes with price and liquidity data."
+version: 1.1.0
 metadata:
   openclaw:
     tags:
@@ -12,7 +12,7 @@ metadata:
 
 # DexPaprika Token Discovery
 
-Search 5M+ tokens and pools across DEXes with price and liquidity data.
+Search 33M+ tokens and 36M+ pools across 230+ DEXes with price and liquidity data.
 
 ## Source
 

--- a/skills/defi/dexpaprika-dex-aggregator/SKILL.md
+++ b/skills/defi/dexpaprika-dex-aggregator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dexpaprika-dex-aggregator
-description: "Query 5M+ tokens and pools across DEX networks with volume and liquidity data."
-version: 1.0.0
+description: "Query 33M+ tokens and 36M+ pools across 36 DEX networks with volume and liquidity data."
+version: 1.1.0
 metadata:
   openclaw:
     tags:
@@ -12,7 +12,7 @@ metadata:
 
 # DexPaprika DEX Agent
 
-Query 5M+ tokens and pools across DEX networks with volume and liquidity data.
+Query 33M+ tokens and 36M+ pools across 36 DEX networks with volume and liquidity data.
 
 ## Source
 

--- a/skills/defi/dexpaprika-dex-scanner/SKILL.md
+++ b/skills/defi/dexpaprika-dex-scanner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dexpaprika-dex-scanner
-description: "Multi-chain DEX pool discovery with 5M+ tokens, volume analytics, and liquidity tracking."
-version: 1.0.0
+description: "Multi-chain DEX pool discovery across 36 chains with 33M+ tokens, volume analytics, and liquidity tracking."
+version: 1.1.0
 metadata:
   openclaw:
     tags:
@@ -12,7 +12,7 @@ metadata:
 
 # DexPaprika DEX Agent
 
-Multi-chain DEX pool discovery with 5M+ tokens, volume analytics, and liquidity tracking.
+Multi-chain DEX pool discovery across 36 chains with 33M+ tokens, volume analytics, and liquidity tracking.
 
 ## Source
 

--- a/skills/mcp-servers/coinpaprika-mcp/SKILL.md
+++ b/skills/mcp-servers/coinpaprika-mcp/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 
 # CoinPaprika MCP Server
 
-Official CoinPaprika MCP server providing real-time cryptocurrency market data for 12,000+ coins and 350+ exchanges. 31 tools for tickers, OHLCV candles, exchange data, search, price conversion, and contract lookup. Free tier with 20,000 calls/month at 10 requests/second per IP, no API key required.
+Official CoinPaprika MCP server providing real-time cryptocurrency market data for 12,000+ coins and 350+ exchanges. 31 tools for tickers, OHLCV candles, exchange data, search, price conversion, and contract lookup. Free tier, no API key required; plans and quotas at https://coinpaprika.com/api/pricing.
 
 ## Installation
 

--- a/skills/mcp-servers/coinpaprika-mcp/SKILL.md
+++ b/skills/mcp-servers/coinpaprika-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: coinpaprika-mcp
-description: "Official CoinPaprika MCP server — real-time crypto market data for 12K+ coins and 350+ exchanges. 30 tools for tickers, OHLCV, exchange data, search, and price conversion. Free tier available."
-version: 1.0.0
+description: "Official CoinPaprika MCP server — real-time crypto market data for 12K+ coins and 350+ exchanges. 31 tools for tickers, OHLCV, exchange data, search, and price conversion. Free tier available."
+version: 1.1.0
 metadata:
   openclaw:
     tags: [coinpaprika, market-data, prices, exchanges, mcp, official]
@@ -11,7 +11,7 @@ metadata:
 
 # CoinPaprika MCP Server
 
-Official CoinPaprika MCP server providing real-time cryptocurrency market data for 12,000+ coins and 350+ exchanges. 30 tools for tickers, OHLCV candles, exchange data, search, price conversion, and contract lookup. Free tier with 10,000 requests/day, no API key required.
+Official CoinPaprika MCP server providing real-time cryptocurrency market data for 12,000+ coins and 350+ exchanges. 31 tools for tickers, OHLCV candles, exchange data, search, price conversion, and contract lookup. Free tier with 20,000 calls/month at 10 requests/second per IP, no API key required.
 
 ## Installation
 
@@ -26,7 +26,7 @@ claude mcp add coinpaprika -- npx @coinpaprika/mcp
 claude mcp add coinpaprika --transport http https://mcp.coinpaprika.com/streamable-http
 ```
 
-## Tools (30)
+## Tools (31)
 
 ### Discovery & System
 - `getCapabilities` — Server capabilities and workflow patterns

--- a/skills/mcp-servers/dexpaprika-mcp/SKILL.md
+++ b/skills/mcp-servers/dexpaprika-mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dexpaprika-mcp
-description: "Official DexPaprika MCP server providing real-time DEX data on 5M+ tokens across 20+ blockchain networks."
-version: 1.0.0
+description: "Official DexPaprika MCP server providing DEX data on 33M+ tokens and 36M+ pools across 36 blockchain networks."
+version: 1.1.0
 metadata:
   openclaw:
     tags: [dexpaprika, dex, tokens, market-data, official]
@@ -13,18 +13,24 @@ metadata:
 
 Official MCP server from CoinPaprika.
 
-Official DexPaprika MCP server providing real-time DEX data on 5M+ tokens across 20+ blockchain networks. Access decentralized exchange analytics, token metrics, and market data through a structured MCP interface.
+Official DexPaprika MCP server providing DEX data on 33M+ tokens and 36M+ pools across 36 blockchain networks. Access decentralized exchange analytics, token metrics, and market data through a structured MCP interface. The self-host npm build registers 16 read tools; the hosted server registers 17 (the same 16 plus submitFeedback). Free tier: 200,000 requests/month keyless per IP or 500,000 with a free key, both at 30 requests/minute, with data delayed up to 15 seconds. Pro is $99/month for 5,000,000 requests at 300/minute with real-time data.
 
 ## Installation
 
 ```bash
-# From the official repo:
-git clone https://github.com/coinpaprika/dexpaprika-mcp
-cd dexpaprika-mcp
-npm install
+# npm (local)
+npx dexpaprika-mcp@latest
+
+# Claude Code
+claude mcp add dexpaprika -- npx dexpaprika-mcp@latest
+
+# Hosted (zero setup)
+claude mcp add dexpaprika --transport http https://mcp.dexpaprika.com/streamable-http
 ```
 
 ## Links
 
 - **GitHub**: https://github.com/coinpaprika/dexpaprika-mcp
-- **Documentation**: https://github.com/coinpaprika/dexpaprika-mcp#readme
+- **Hosted MCP**: https://mcp.dexpaprika.com
+- **API Docs**: https://docs.dexpaprika.com
+- **npm**: https://www.npmjs.com/package/dexpaprika-mcp

--- a/skills/mcp-servers/dexpaprika-mcp/SKILL.md
+++ b/skills/mcp-servers/dexpaprika-mcp/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 Official MCP server from CoinPaprika.
 
-Official DexPaprika MCP server providing DEX data on 33M+ tokens and 36M+ pools across 36 blockchain networks. Access decentralized exchange analytics, token metrics, and market data through a structured MCP interface. The self-host npm build registers 16 read tools; the hosted server registers 17 (the same 16 plus submitFeedback). Free tier: 200,000 requests/month keyless per IP or 500,000 with a free key, both at 30 requests/minute, with data delayed up to 15 seconds. Pro is $99/month for 5,000,000 requests at 300/minute with real-time data.
+Official DexPaprika MCP server providing DEX data on 33M+ tokens and 36M+ pools across 36 blockchain networks. Access decentralized exchange analytics, token metrics, and market data through a structured MCP interface. The self-host npm build registers 16 read tools; the hosted server registers 17 (the same 16 plus submitFeedback). Free tier, no API key required: 30 requests/minute with data delayed up to 15 seconds, and a free key raises the monthly quota. Pro is $99/month for real-time data at 300 requests/minute with a 99.5% SLA. Current quotas: https://dexpaprika.com/api/pricing.
 
 ## Installation
 

--- a/skills/trading/dex-paprika-aggregator/SKILL.md
+++ b/skills/trading/dex-paprika-aggregator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dex-paprika-aggregator
-description: "Query 5M+ tokens and liquidity pools across 30+ blockchain networks for DEX analytics."
-version: 1.0.0
+description: "Query 33M+ tokens and 36M+ liquidity pools across 36 blockchain networks for DEX analytics."
+version: 1.1.0
 metadata:
   openclaw:
     tags:
@@ -12,7 +12,7 @@ metadata:
 
 # DexPaprika DEX Data
 
-Query 5M+ tokens and liquidity pools across 30+ blockchain networks for DEX analytics.
+Query 33M+ tokens and 36M+ liquidity pools across 36 blockchain networks for DEX analytics.
 
 ## Source
 


### PR DESCRIPTION
Eight `SKILL.md` files under `skills/`, all Paprika entries, all carrying figures that have moved. No other project's files are touched.

## What was wrong

| claim | reality today |
|---|---|
| `10,000 requests/day` | retired. The free tier is monthly, and the number moved on 2026-08-11 |
| `34+ blockchains` | 36 |
| `30M+ pools` | 36M+ |
| `14 MCP tools` | 17 |
| `5M+ tokens` | 33M+ |

Verified rather than copied from a changelog:

```
$ curl -s https://api.dexpaprika.com/stats
{"chains":36,"factories":235,"pools":38683633,"tokens":35580736}

$ curl -s -X POST https://mcp.dexpaprika.com/json-rpc \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
17 tools
```

## Where quotas are concerned, the entries now link rather than restate

The monthly allowance changed on 2026-08-11 and can change again. Anywhere a figure was not structurally required, the text points at https://dexpaprika.com/api/pricing instead. A second copy of a moving number is a future correction.

## Deliberately left alone

**CoinPaprika's free tier really is 20,000 calls a month**, so those lines are correct as written and are untouched.

The eighth file, `skills/analytics/coinpaprika-official-claude-marketplace/SKILL.md`, was outside the seven this PR opened with. It carried the same retired quota, so it is folded in here rather than left for a follow-up.

I work on these APIs, so this corrects my own entries.